### PR TITLE
Fix object retrieval logic

### DIFF
--- a/src/Extensions/ObjectsRepositoryEx.cs
+++ b/src/Extensions/ObjectsRepositoryEx.cs
@@ -52,7 +52,7 @@ namespace PilotLookUp.Extensions
             var userStateMachine = userStateMachines.FirstOrDefault(i => i.Id == guid);
             if (userStateMachine != null)
             {
-                return userStateMachines;
+                return userStateMachine;
             }
 
             return null;


### PR DESCRIPTION
## Summary
- return the specific UserStateMachine object when found

## Testing
- `dotnet build src/PilotLookUp.csproj` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68408c4df6c48321b0b52751af7b2067